### PR TITLE
Remove unnecessary javafx imports.

### DIFF
--- a/MROZA-Show/MROZA-Show-ejb/src/main/java/com/mroza/dao/TablesDao.java
+++ b/MROZA-Show/MROZA-Show-ejb/src/main/java/com/mroza/dao/TablesDao.java
@@ -19,7 +19,6 @@
 package com.mroza.dao;
 
 import com.mroza.models.Table;
-import javafx.scene.control.Tab;
 import org.apache.ibatis.session.SqlSession;
 
 import javax.inject.Inject;

--- a/MROZA-Show/MROZA-Show-ejb/src/test/java/com/mroza/service/KidProgramServiceDbImplTests/KidProgramServiceDbImplDeleteTableTest.java
+++ b/MROZA-Show/MROZA-Show-ejb/src/test/java/com/mroza/service/KidProgramServiceDbImplTests/KidProgramServiceDbImplDeleteTableTest.java
@@ -27,7 +27,6 @@ import com.mroza.models.Table;
 import com.mroza.service.KidProgramsServiceDbImpl;
 import com.mroza.utils.DatabaseUtils;
 import com.mroza.utils.ReflectionWrapper;
-import javafx.scene.control.Tab;
 import org.apache.ibatis.session.SqlSession;
 import org.junit.After;
 import org.junit.Before;


### PR DESCRIPTION
Just small improvement. Imports can cause problems with openJDK, since it may not contain javafx.
