### PR TITLE
Fix start date of period in calendar (#35)

### DIFF
--- a/MROZA-Show/MROZA-Show-lib/src/main/java/com/mroza/models/Period.java
+++ b/MROZA-Show/MROZA-Show-lib/src/main/java/com/mroza/models/Period.java
@@ -18,16 +18,15 @@
 
 package com.mroza.models;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.io.Serializable;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -60,5 +59,17 @@ public class Period implements Serializable {
     public Period(Integer id) {
         this.id = id;
         this.kidTables = new ArrayList<>();
+    }
+    public void setBeginDate(Date beginDate) {
+    	this.beginDate = new Date(beginDate.getTime());
+    }
+    public Date getBeginDate() {
+    	return new Date(beginDate.getTime());
+    }
+    public void setEndDate(Date endDate) {
+    	this.endDate = new Date(endDate.getTime());
+    }
+    public Date getEndDate() {
+    	return new Date(endDate.getTime());
     }
 }

--- a/MROZA-Show/MROZA-Show-web/src/main/java/com/mroza/viewbeans/kidprograms/model/ScheduldeEventWrapper.java
+++ b/MROZA-Show/MROZA-Show-web/src/main/java/com/mroza/viewbeans/kidprograms/model/ScheduldeEventWrapper.java
@@ -24,6 +24,7 @@ import org.primefaces.model.ScheduleEvent;
 
 import javax.xml.crypto.Data;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 
 public class ScheduldeEventWrapper {
@@ -53,6 +54,7 @@ public class ScheduldeEventWrapper {
         applyHackToHandlePrimefacesComponentWayHandlingCalendarDays(period);
         calendarRepresentation.setStartDate(period.getBeginDate());
         calendarRepresentation.setEndDate(period.getEndDate());
+        calendarRepresentation.setAllDay(true);
         calendarRepresentation.setTitle(getCalendarRepresentationTitleFromPeriod(period));
     }
 
@@ -61,8 +63,25 @@ public class ScheduldeEventWrapper {
         return dateFormat.format(period.getBeginDate()) + " - " + dateFormat.format(period.getEndDate());
     }
 
+    /**
+     * Primefaces schedule component doesn't show event on first/last day in case that hour is 0:00
+     * 
+     * @param period
+     */
     private static void applyHackToHandlePrimefacesComponentWayHandlingCalendarDays(Period period) {
-        period.getEndDate().setHours(12); // primefaces schedule component doesn't show event on last day in case that hour is 0:00
+    	
+    	int dayStartHour = 1;
+    	int dayEndHour = 23;
+    	
+    	Calendar cal = Calendar.getInstance();
+    	
+    	cal.setTime(period.getBeginDate());
+    	cal.set(Calendar.HOUR_OF_DAY, dayStartHour);
+    	period.setBeginDate(cal.getTime());
+    	
+    	cal.setTime(period.getEndDate());
+    	cal.set(Calendar.HOUR_OF_DAY, dayEndHour);
+        period.setEndDate(cal.getTime()); 
     }
 
 


### PR DESCRIPTION
- set hour for begin date (still bit of hack, for all day events) in ScheduldeEventWrapper
- set period representation as taking all day
- defensive copy of Date in Period
